### PR TITLE
Fix php 7.2 unset cast deprecated warning

### DIFF
--- a/YaLinqo/Enumerable.php
+++ b/YaLinqo/Enumerable.php
@@ -85,7 +85,7 @@ class Enumerable implements \IteratorAggregate
                 return $this->select(function ($v) { return (float)$v; });
             case 'null':
             case 'unset':
-                return $this->select(function ($v) { return (unset)$v; });
+                return $this->select(function ($v) { return null; });
             case 'object':
                 return $this->select(function ($v) { return (object)$v; });
             case 'string':


### PR DESCRIPTION
This fix project compatibility with php 7.2, at least in my use case. This was the main deprecated warning I got after upgrading to 7.2, and acording to the [docs](https://wiki.php.net/rfc/deprecations_php_7_2#unset_cast), produces the same result.