### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
         "docs": "http://athari.github.io/YaLinqo"
     },
     "require": {
-        "php": ">=5.5"
+        "php": ">=7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "<6",
         "phpdocumentor/phpdocumentor": "^2.8",
-        "satooshi/php-coveralls": "^2.0"
+        "php-coveralls/php-coveralls": "^2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
-  PHP versions below 7.0 are not tested under, should not be shown as supported.
- php-coveralls now has is a different package

See  #25