### PR TITLE
Update Enumerable.php

### DIFF
--- a/YaLinqo/Enumerable.php
+++ b/YaLinqo/Enumerable.php
@@ -47,6 +47,7 @@ class Enumerable implements \IteratorAggregate
      * {@inheritdoc}
      * @return \Iterator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator ()
     {
         return $this->iterator;


### PR DESCRIPTION
Fix Deprecated: Return type of YaLinqo\Enumerable::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /vendor/athari/yalinqo/YaLinqo/Enumerable.php on line 50 1